### PR TITLE
Update ioc-extractor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2460,9 +2460,9 @@
       "dev": true
     },
     "ioc-extractor": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/ioc-extractor/-/ioc-extractor-0.2.2.tgz",
-      "integrity": "sha512-8ArxNXMqmkKG79Fm6JwqOgIspNZH+cAgeMX70bozj8zV3v2MPqWtSZvLbXOqg6E6xG51Wj94pm+Z+RFvLSrJsg=="
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/ioc-extractor/-/ioc-extractor-0.2.3.tgz",
+      "integrity": "sha512-rLCvcqHzN76ZPZmHlGDG+URTIx54GxADyJc6kFQdQnvued7otdCCtM1vgJovGewUgnuqJBtmaS8vTx4ww4zBsQ=="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "axios": "^0.18.0",
     "crypto-js": "^3.1.9-1",
-    "ioc-extractor": "^0.2.2",
+    "ioc-extractor": "^0.2.3",
     "url": "^0.11.0",
     "validator": "^10.4.0"
   },


### PR DESCRIPTION
There is [an issue](https://github.com/ninoseki/ioc-extractor/pull/7) in `ioc-extractor` v0.2.2 so I update the package to v.0.2.3.
