### PR TITLE
Switch to clear the context menus in `document.onselectstart`

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -53,38 +53,40 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
 });
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.request === "removeContextMenu") {
+    chrome.contextMenus.removeAll();
+  }
+
   if (message.request === "updateContextMenu") {
-    chrome.contextMenus.removeAll(() => {
-      // search searchers based on a type of the input
-      const text: string = message.selection;
-      const selector: Selector = new Selector(text);
-      const searcherEntries: AnalyzerEntry[] = selector.getSearcherEntries();
-      for (const entry of searcherEntries) {
-        const name = entry.analyzer.name;
-        // it tells action/query/type/target to the listner
-        const id = `Search ${entry.query} as a ${entry.type} on ${name}`;
-        const title = `Search this ${entry.type} on ${name}`;
-        const options = {
-          contexts: ["selection"],
-          id,
-          title,
-        };
-        chrome.contextMenus.create(options);
-      }
-      // search scanners based on a type of the input
-      const scannerEntries: AnalyzerEntry[] = selector.getScannerEntries();
-      for (const entry of scannerEntries) {
-        const name = entry.analyzer.name;
-        // it tells action/query/type/target to the listner
-        const id = `Scan ${entry.query} as a ${entry.type} on ${name}`;
-        const title = `Scan this ${entry.type} on ${name}`;
-        const options = {
-          contexts: ["selection"],
-          id,
-          title,
-        };
-        chrome.contextMenus.create(options);
-      }
-    });
+    // search searchers based on a type of the input
+    const text: string = message.selection;
+    const selector: Selector = new Selector(text);
+    const searcherEntries: AnalyzerEntry[] = selector.getSearcherEntries();
+    for (const entry of searcherEntries) {
+      const name = entry.analyzer.name;
+      // it tells action/query/type/target to the listner
+      const id = `Search ${entry.query} as a ${entry.type} on ${name}`;
+      const title = `Search this ${entry.type} on ${name}`;
+      const options = {
+        contexts: ["selection"],
+        id,
+        title,
+      };
+      chrome.contextMenus.create(options);
+    }
+    // search scanners based on a type of the input
+    const scannerEntries: AnalyzerEntry[] = selector.getScannerEntries();
+    for (const entry of scannerEntries) {
+      const name = entry.analyzer.name;
+      // it tells action/query/type/target to the listner
+      const id = `Scan ${entry.query} as a ${entry.type} on ${name}`;
+      const title = `Scan this ${entry.type} on ${name}`;
+      const options = {
+        contexts: ["selection"],
+        id,
+        title,
+      };
+      chrome.contextMenus.create(options);
+    }
   }
 });

--- a/src/content.ts
+++ b/src/content.ts
@@ -16,3 +16,7 @@ document.onselectionchange = () => {
     });
   }
 };
+
+document.onselectstart = () => {
+  chrome.runtime.sendMessage({ request: "removeContextMenu" });
+};


### PR DESCRIPTION
- Before:
  - Clear the context menus before creating context menus in an event which is triggered by `document.onselectionchange`.
- After:
  - Clear the context menus in an event which is triggered by `document.onselectstart`.

It works better than before in my env.