### PR TITLE
refactor: remove public accessor within classes

### DIFF
--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -3,9 +3,9 @@ import { Searcher } from "./searcher";
 import { AnalyzerEntry, Selector } from "./selector";
 
 export class Command {
-  public action: string;
-  public query: string;
-  public target: string;
+  action: string;
+  query: string;
+  target: string;
 
   constructor(command: string) {
     const parts: string[] = command.split(" ");
@@ -14,7 +14,7 @@ export class Command {
     this.target = parts[parts.length - 1];
   }
 
-  public search(): string {
+  search(): string {
     const selector: Selector = new Selector(this.query);
     const entries: AnalyzerEntry[] = selector.getSearcherEntries();
     const entry = entries.find((r) => r.analyzer.name === this.target);
@@ -65,7 +65,7 @@ export class Command {
     return url;
   }
 
-  public async scan(apiKeys: ApiKeys) {
+  async scan(apiKeys: ApiKeys) {
     const selector: Selector = new Selector(this.query);
     const entries: AnalyzerEntry[] = selector.getScannerEntries();
     const entry = entries.find((r) => r.analyzer.name === this.target);

--- a/src/lib/scanner/urlscan.ts
+++ b/src/lib/scanner/urlscan.ts
@@ -2,9 +2,9 @@ import axios from "axios";
 import { ScannableType, Scanner } from "./scanner";
 
 export class Urlscan implements Scanner {
-  public endpoint: string;
-  public name: string;
-  public supportedTypes: ScannableType[] = ["ip", "domain", "url"];
+  endpoint: string;
+  name: string;
+  supportedTypes: ScannableType[] = ["ip", "domain", "url"];
   protected apiKey: string | undefined;
 
   constructor() {
@@ -12,19 +12,19 @@ export class Urlscan implements Scanner {
     this.name = "Urlscan";
   }
 
-  public setApiKey(apiKey) {
+  setApiKey(apiKey) {
     this.apiKey = apiKey;
   }
 
-  public async scanByIP(ip) {
+  async scanByIP(ip) {
     return await this.scan(ip);
   }
 
-  public async scanByDomain(domain) {
+  async scanByDomain(domain) {
     return await this.scan(domain);
   }
 
-  public async scanByURL(url) {
+  async scanByURL(url) {
     return await this.scan(url);
   }
 

--- a/src/lib/scanner/virustotal.ts
+++ b/src/lib/scanner/virustotal.ts
@@ -4,9 +4,9 @@ import { ScannableType, Scanner } from "./scanner";
 
 export class VirusTotal implements Scanner {
 
-  public endpoint: string;
-  public name: string;
-  public supportedTypes: ScannableType[] = ["url"];
+  endpoint: string;
+  name: string;
+  supportedTypes: ScannableType[] = ["url"];
   protected apiKey: string | undefined;
 
   constructor() {
@@ -14,11 +14,11 @@ export class VirusTotal implements Scanner {
     this.name = "VirusTotal";
   }
 
-  public setApiKey(apiKey) {
+  setApiKey(apiKey) {
     this.apiKey = apiKey;
   }
 
-  public async scanByURL(url) {
+  async scanByURL(url) {
     if (this.apiKey === undefined) {
       throw Error("Please set your VirusTotal API key via the option.");
     }

--- a/src/lib/searcher/bgpview.ts
+++ b/src/lib/searcher/bgpview.ts
@@ -2,20 +2,20 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class BGPView implements Searcher {
 
-  public endpoint: string;
-  public name: string;
-  public supportedTypes: SearchableType[] = ["ip", "asn"];
+  endpoint: string;
+  name: string;
+  supportedTypes: SearchableType[] = ["ip", "asn"];
 
   constructor() {
     this.endpoint = "https://bgpview.io";
     this.name = "BGPView";
   }
 
-  public searchByIP(query) {
+  searchByIP(query) {
     return `${this.endpoint}/ip/${query}`;
   }
 
-  public searchByASN(query) {
+  searchByASN(query) {
     const matches = query.match(/\d+$/);
     if (matches !== null && matches[0]) {
       return `${this.endpoint}/asn/${matches[0]}`;

--- a/src/lib/searcher/blockcypher.ts
+++ b/src/lib/searcher/blockcypher.ts
@@ -2,16 +2,16 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class BlockCypher implements Searcher {
 
-  public endpoint: string;
-  public name: string;
-  public supportedTypes: SearchableType[] = ["btc"];
+  endpoint: string;
+  name: string;
+  supportedTypes: SearchableType[] = ["btc"];
 
   constructor() {
     this.endpoint = "https://live.blockcypher.com";
     this.name = "BlockCypher";
   }
 
-  public searchByBTC(query) {
+  searchByBTC(query) {
     return `${this.endpoint}/btc/address/${query}/`;
   }
 }

--- a/src/lib/searcher/censys.ts
+++ b/src/lib/searcher/censys.ts
@@ -2,16 +2,16 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class Censys implements Searcher {
 
-  public endpoint: string;
-  public name: string;
-  public supportedTypes: SearchableType[] = ["text"];
+  endpoint: string;
+  name: string;
+  supportedTypes: SearchableType[] = ["text"];
 
   constructor() {
     this.endpoint = "https://censys.io";
     this.name = "Censys";
   }
 
-  public searchByText(query) {
+  searchByText(query) {
     const encoded = encodeURIComponent(query);
     return `${this.endpoint}/ipv4?q=${encoded}`;
   }

--- a/src/lib/searcher/cymon.ts
+++ b/src/lib/searcher/cymon.ts
@@ -2,20 +2,20 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class Cymon implements Searcher {
 
-  public endpoint: string;
-  public name;
-  public supportedTypes: SearchableType[] = ["ip", "domain"];
+  endpoint: string;
+  name;
+  supportedTypes: SearchableType[] = ["ip", "domain"];
 
   constructor() {
     this.endpoint = "https://cymon.io";
     this.name = "Cymon";
   }
 
-  public searchByIP(query) {
+  searchByIP(query) {
     return `${this.endpoint}/${query}`;
   }
 
-  public searchByDomain(query) {
+  searchByDomain(query) {
     return `${this.endpoint}/domain/${query}`;
   }
 }

--- a/src/lib/searcher/dnslytics.ts
+++ b/src/lib/searcher/dnslytics.ts
@@ -2,20 +2,20 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class DNSlytics implements Searcher {
 
-  public endpoint: string;
-  public name;
-  public supportedTypes: SearchableType[] = ["ip", "domain"];
+  endpoint: string;
+  name;
+  supportedTypes: SearchableType[] = ["ip", "domain"];
 
   constructor() {
     this.endpoint = "https://dnslytics.com";
     this.name = "DNSlytics";
   }
 
-  public searchByIP(query) {
+  searchByIP(query) {
     return `${this.endpoint}/ip/${query}`;
   }
 
-  public searchByDomain(query) {
+  searchByDomain(query) {
     return `${this.endpoint}/domain/${query}`;
   }
 }

--- a/src/lib/searcher/domainbigdata.ts
+++ b/src/lib/searcher/domainbigdata.ts
@@ -2,16 +2,16 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class DomainBigData implements Searcher {
 
-  public endpoint: string;
-  public name;
-  public supportedTypes: SearchableType[] = ["domain"];
+  endpoint: string;
+  name;
+  supportedTypes: SearchableType[] = ["domain"];
 
   constructor() {
     this.endpoint = "https://domainbigdata.com";
     this.name = "DomainBigData";
   }
 
-  public searchByDomain(query) {
+  searchByDomain(query) {
     return `${this.endpoint}/${query}`;
   }
 }

--- a/src/lib/searcher/domainwatch.ts
+++ b/src/lib/searcher/domainwatch.ts
@@ -2,20 +2,20 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class DomainWatch implements Searcher {
 
-  public endpoint: string;
-  public name;
-  public supportedTypes: SearchableType[] = ["domain", "email"];
+  endpoint: string;
+  name;
+  supportedTypes: SearchableType[] = ["domain", "email"];
 
   constructor() {
     this.endpoint = "https://domainwat.ch";
     this.name = "DomainWatch";
   }
 
-  public searchByDomain(query) {
+  searchByDomain(query) {
     return `${this.endpoint}/whois/${query}`;
   }
 
-  public searchByEmail(query) {
+  searchByEmail(query) {
     return `${this.endpoint}/search?query=${encodeURIComponent(query)}`;
   }
 }

--- a/src/lib/searcher/findsubdomains.ts
+++ b/src/lib/searcher/findsubdomains.ts
@@ -2,16 +2,16 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class FindSubDomains implements Searcher {
 
-  public endpoint: string;
-  public name: string;
-  public supportedTypes: SearchableType[] = ["domain"];
+  endpoint: string;
+  name: string;
+  supportedTypes: SearchableType[] = ["domain"];
 
   constructor() {
     this.endpoint = "https://findsubdomains.com";
     this.name = "FindSubDomains";
   }
 
-  public searchByDomain(query) {
+  searchByDomain(query) {
     return `${this.endpoint}/subdomains-of/${query}`;
   }
 }

--- a/src/lib/searcher/fofa.ts
+++ b/src/lib/searcher/fofa.ts
@@ -4,21 +4,21 @@ import * as crypto from "crypto-js";
 
 export class FOFA implements Searcher {
 
-  public endpoint: string;
-  public name;
-  public supportedTypes: SearchableType[] = ["ip", "domain"];
+  endpoint: string;
+  name;
+  supportedTypes: SearchableType[] = ["ip", "domain"];
 
   constructor() {
     this.endpoint = "https://fofa.so";
     this.name = "FOFA";
   }
 
-  public searchByIP(query) {
+  searchByIP(query) {
     const param = `ip="${query}"`;
     return `${this.endpoint}/result?qbase64=${this.base64fy(param)}`;
   }
 
-  public searchByDomain(query) {
+  searchByDomain(query) {
     const param = `domain="${query}"`;
     return `${this.endpoint}/result?qbase64=${this.base64fy(param)}`;
   }

--- a/src/lib/searcher/fortiguard.ts
+++ b/src/lib/searcher/fortiguard.ts
@@ -2,26 +2,26 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class FortiGuard implements Searcher {
 
-  public endpoint: string;
-  public name: string;
-  public supportedTypes: SearchableType[] = ["ip", "url", "cve"];
+  endpoint: string;
+  name: string;
+  supportedTypes: SearchableType[] = ["ip", "url", "cve"];
 
   constructor() {
     this.endpoint = "https://fortiguard.com";
     this.name = "FortiGuard";
   }
 
-  public searchByIP(query) {
+  searchByIP(query) {
     return `${this.endpoint}/search?q=${query}&engine=8`;
   }
 
-  public searchByURL(query) {
+  searchByURL(query) {
     const encoded = encodeURIComponent(query);
     return `${this.endpoint}/webfilter?q=${encoded}`;
 
   }
 
-  public searchByCVE(query) {
+  searchByCVE(query) {
     return `${this.endpoint}/search?q=${query}&engine=3`;
   }
 }

--- a/src/lib/searcher/hybridanalysis.ts
+++ b/src/lib/searcher/hybridanalysis.ts
@@ -1,28 +1,28 @@
 import { SearchableType, Searcher } from "./searcher";
 
 export class HybridAnalysis implements Searcher {
-  public endpoint: string;
-  public name: string;
-  public supportedTypes: SearchableType[] = ["ip", "domain", "hash"];
+  endpoint: string;
+  name: string;
+  supportedTypes: SearchableType[] = ["ip", "domain", "hash"];
 
   constructor() {
     this.endpoint = "https://www.hybrid-analysis.com";
     this.name = "HybridAnalysis";
   }
 
-  public searchByHash(query) {
+  searchByHash(query) {
     if (query.length !== 64) {
       throw new Error("HybridAnalysis onlys suports SHA256");
     }
     return `${this.endpoint}/sample/${query}`;
   }
 
-  public searchByIP(query) {
+  searchByIP(query) {
     const q = encodeURIComponent(`host:${query}`);
     return `${this.endpoint}/search?query=${q}`;
   }
 
-  public searchByDomain(query) {
+  searchByDomain(query) {
     const q = encodeURIComponent(`domain:${query}`);
     return `${this.endpoint}/search?query=${q}`;
   }

--- a/src/lib/searcher/intelligencex.ts
+++ b/src/lib/searcher/intelligencex.ts
@@ -2,32 +2,32 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class IntelligenceX implements Searcher {
 
-  public endpoint: string;
-  public name: string;
-  public supportedTypes: SearchableType[] = ["ip", "domain", "url", "email", "btc"];
+  endpoint: string;
+  name: string;
+  supportedTypes: SearchableType[] = ["ip", "domain", "url", "email", "btc"];
 
   constructor() {
     this.endpoint = "https://intelx.io";
     this.name = "IntelligenceX";
   }
 
-  public searchByIP(query) {
+  searchByIP(query) {
     return this.search(query);
   }
 
-  public searchByDomain(query) {
+  searchByDomain(query) {
     return this.search(query);
   }
 
-  public searchByURL(query) {
+  searchByURL(query) {
     return this.search(query);
   }
 
-  public searchByEmail(query) {
+  searchByEmail(query) {
     return this.search(query);
   }
 
-  public searchByBTC(query) {
+  searchByBTC(query) {
     return this.search(query);
   }
 

--- a/src/lib/searcher/onyphe.ts
+++ b/src/lib/searcher/onyphe.ts
@@ -2,16 +2,16 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class ONYPHE implements Searcher {
 
-  public endpoint: string;
-  public name: string;
-  public supportedTypes: SearchableType[] = ["ip"];
+  endpoint: string;
+  name: string;
+  supportedTypes: SearchableType[] = ["ip"];
 
   constructor() {
     this.endpoint = "https://www.onyphe.io";
     this.name = "ONYPHE";
   }
 
-  public searchByIP(query) {
+  searchByIP(query) {
     return `${this.endpoint}/ip/${query}`;
   }
 }

--- a/src/lib/searcher/otx.ts
+++ b/src/lib/searcher/otx.ts
@@ -2,23 +2,23 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class OTX implements Searcher {
 
-  public endpoint: string;
-  public name: string;
-  public supportedTypes: SearchableType[] = ["ip", "domain", "hash"];
+  endpoint: string;
+  name: string;
+  supportedTypes: SearchableType[] = ["ip", "domain", "hash"];
 
   constructor() {
     this.endpoint = "https://otx.alienvault.com";
     this.name = "OTX";
   }
 
-  public searchByIP(query) {
+  searchByIP(query) {
     return `${this.endpoint}/indicator/ip/${query}`;
   }
-  public searchByDomain(query) {
+  searchByDomain(query) {
     return `${this.endpoint}/indicator/domain/${query}`;
   }
 
-  public searchByHash(query) {
+  searchByHash(query) {
     return `${this.endpoint}/indicator/file/${query}`;
   }
 }

--- a/src/lib/searcher/pipl.ts
+++ b/src/lib/searcher/pipl.ts
@@ -2,16 +2,16 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class Pipl implements Searcher {
 
-  public endpoint: string;
-  public name;
-  public supportedTypes: SearchableType[] = ["email"];
+  endpoint: string;
+  name;
+  supportedTypes: SearchableType[] = ["email"];
 
   constructor() {
     this.endpoint = "https://pipl.com";
     this.name = "Pipl";
   }
 
-  public searchByEmail(query) {
+  searchByEmail(query) {
     return `${this.endpoint}/search/?q=${encodeURIComponent(query)}`;
   }
 }

--- a/src/lib/searcher/pubdb.ts
+++ b/src/lib/searcher/pubdb.ts
@@ -2,20 +2,20 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class PubDB implements Searcher {
 
-  public endpoint: string;
-  public name;
-  public supportedTypes: SearchableType[] = ["gaTrackID", "gaPubID"];
+  endpoint: string;
+  name;
+  supportedTypes: SearchableType[] = ["gaTrackID", "gaPubID"];
 
   constructor() {
     this.endpoint = "http://pub-db.com";
     this.name = "PubDB";
   }
 
-  public searchByGATrackID(query) {
+  searchByGATrackID(query) {
     return `${this.endpoint}/google-analytics/${query}.html`;
   }
 
-  public searchByGAPubID(query) {
+  searchByGAPubID(query) {
     return `${this.endpoint}/adsense/${query}.html`;
   }
 }

--- a/src/lib/searcher/publicwww.ts
+++ b/src/lib/searcher/publicwww.ts
@@ -2,16 +2,16 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class PublicWWW implements Searcher {
 
-  public endpoint: string;
-  public name: string;
-  public supportedTypes: SearchableType[] = ["text"];
+  endpoint: string;
+  name: string;
+  supportedTypes: SearchableType[] = ["text"];
 
   constructor() {
     this.endpoint = "https://publicwww.com/websites";
     this.name = "PublicWWW";
   }
 
-  public searchByText(query) {
+  searchByText(query) {
     const encoded = encodeURIComponent(query);
     return `${this.endpoint}/${encoded}`;
   }

--- a/src/lib/searcher/pulsedive.ts
+++ b/src/lib/searcher/pulsedive.ts
@@ -3,25 +3,25 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class Pulsedive implements Searcher {
 
-  public endpoint: string;
-  public name: string;
-  public supportedTypes: SearchableType[] = ["ip", "domain", "url", "hash"];
+  endpoint: string;
+  name: string;
+  supportedTypes: SearchableType[] = ["ip", "domain", "url", "hash"];
 
   constructor() {
     this.endpoint = "https://pulsedive.com";
     this.name = "Pulsedive";
   }
 
-  public searchByIP(query) {
+  searchByIP(query) {
     return this.search(query);
   }
-  public searchByDomain(query) {
+  searchByDomain(query) {
     return this.search(query);
   }
-  public searchByURL(query) {
+  searchByURL(query) {
     return this.search(query);
   }
-  public searchByHash(query) {
+  searchByHash(query) {
     return this.search(query);
   }
 

--- a/src/lib/searcher/riskiq.ts
+++ b/src/lib/searcher/riskiq.ts
@@ -2,24 +2,24 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class RiskIQ implements Searcher {
 
-  public endpoint: string;
-  public name;
-  public supportedTypes: SearchableType[] = ["ip", "domain", "email"];
+  endpoint: string;
+  name;
+  supportedTypes: SearchableType[] = ["ip", "domain", "email"];
 
   constructor() {
     this.endpoint = "https://community.riskiq.com";
     this.name = "RiskIQ";
   }
 
-  public searchByIP(query) {
+  searchByIP(query) {
     return `${this.endpoint}/search/${query}`;
   }
 
-  public searchByDomain(query) {
+  searchByDomain(query) {
     return `${this.endpoint}/search/${query}`;
   }
 
-  public searchByEmail(query) {
+  searchByEmail(query) {
     return `${this.endpoint}/search/whois/email/${query}`;
   }
 }

--- a/src/lib/searcher/securitytrails.ts
+++ b/src/lib/searcher/securitytrails.ts
@@ -2,25 +2,25 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class SecurityTrails implements Searcher {
 
-  public endpoint: string;
-  public name: string;
-  public supportedTypes: SearchableType[] = ["ip", "domain"];
+  endpoint: string;
+  name: string;
+  supportedTypes: SearchableType[] = ["ip", "domain"];
 
   constructor() {
     this.endpoint = "https://securitytrails.com";
     this.name = "SecurityTrails";
   }
 
-  public searchByText(query) {
+  searchByText(query) {
     const encoded = encodeURIComponent(query);
     return `${this.endpoint}/list/keyword/${encoded}`;
   }
 
-  public searchByIP(ip) {
+  searchByIP(ip) {
     return `${this.endpoint}/list/ip/${ip}`;
   }
 
-  public searchByDomain(domain) {
+  searchByDomain(domain) {
     return `${this.endpoint}/domain/${domain}`;
   }
 }

--- a/src/lib/searcher/shodan.ts
+++ b/src/lib/searcher/shodan.ts
@@ -2,16 +2,16 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class Shodan implements Searcher {
 
-  public endpoint: string;
-  public name: string;
-  public supportedTypes: SearchableType[] = ["text"];
+  endpoint: string;
+  name: string;
+  supportedTypes: SearchableType[] = ["text"];
 
   constructor() {
     this.endpoint = `https://www.shodan.io`;
     this.name = "Shodan";
   }
 
-  public searchByText(query) {
+  searchByText(query) {
     const encoded = encodeURIComponent(query);
     return `${this.endpoint}/search?query=${encoded}`;
   }

--- a/src/lib/searcher/sploitus.ts
+++ b/src/lib/searcher/sploitus.ts
@@ -2,16 +2,16 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class Sploitus implements Searcher {
 
-  public endpoint: string;
-  public name;
-  public supportedTypes: SearchableType[] = ["cve"];
+  endpoint: string;
+  name;
+  supportedTypes: SearchableType[] = ["cve"];
 
   constructor() {
     this.endpoint = "https://sploitus.com";
     this.name = "Sploitus";
   }
 
-  public searchByCVE(query) {
+  searchByCVE(query) {
     return `${this.endpoint}/?query=${query}`;
   }
 }

--- a/src/lib/searcher/spyonweb.ts
+++ b/src/lib/searcher/spyonweb.ts
@@ -2,28 +2,28 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class SpyOnWeb implements Searcher {
 
-  public endpoint: string;
-  public name;
-  public supportedTypes: SearchableType[] = ["ip", "domain", "gaPubID", "gaTrackID"];
+  endpoint: string;
+  name;
+  supportedTypes: SearchableType[] = ["ip", "domain", "gaPubID", "gaTrackID"];
 
   constructor() {
     this.endpoint = "http://spyonweb.com";
     this.name = "SpyOnWeb";
   }
 
-  public searchByIP(query) {
+  searchByIP(query) {
     return this.search(query);
   }
 
-  public searchByDomain(query) {
+  searchByDomain(query) {
     return this.search(query);
   }
 
-  public searchByGAPubID(query) {
+  searchByGAPubID(query) {
     return this.search(query);
   }
 
-  public searchByGATrackID(query) {
+  searchByGATrackID(query) {
     return this.search(query);
   }
 

--- a/src/lib/searcher/talos.ts
+++ b/src/lib/searcher/talos.ts
@@ -2,20 +2,20 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class Talos implements Searcher {
 
-  public endpoint: string;
-  public name;
-  public supportedTypes: SearchableType[] = ["ip", "domain"];
+  endpoint: string;
+  name;
+  supportedTypes: SearchableType[] = ["ip", "domain"];
 
   constructor() {
     this.endpoint = "https://talosintelligence.com";
     this.name = "Talos";
   }
 
-  public searchByIP(query) {
+  searchByIP(query) {
     return this.search(query);
   }
 
-  public searchByDomain(query) {
+  searchByDomain(query) {
     return this.search(query);
   }
 

--- a/src/lib/searcher/threatcrowd.ts
+++ b/src/lib/searcher/threatcrowd.ts
@@ -2,24 +2,24 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class ThreatCrowd implements Searcher {
 
-  public endpoint: string;
-  public name;
-  public supportedTypes: SearchableType[] = ["ip", "domain", "email"];
+  endpoint: string;
+  name;
+  supportedTypes: SearchableType[] = ["ip", "domain", "email"];
 
   constructor() {
     this.endpoint = "https://www.threatcrowd.org";
     this.name = "ThreatCrowd";
   }
 
-  public searchByIP(query) {
+  searchByIP(query) {
     return `${this.endpoint}/ip.php?ip=${query}`;
   }
 
-  public searchByDomain(query) {
+  searchByDomain(query) {
     return `${this.endpoint}/domain.php?domain=${query}`;
   }
 
-  public searchByEmail(query) {
+  searchByEmail(query) {
     return `${this.endpoint}/email.php?email=${query}`;
   }
 }

--- a/src/lib/searcher/urlscan.ts
+++ b/src/lib/searcher/urlscan.ts
@@ -2,31 +2,31 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class Urlscan implements Searcher {
 
-  public endpoint: string;
-  public name: string;
-  public supportedTypes: SearchableType[] = ["ip", "domain", "url"];
+  endpoint: string;
+  name: string;
+  supportedTypes: SearchableType[] = ["ip", "domain", "url"];
 
   constructor() {
     this.endpoint = "https://urlscan.io/api/v1";
     this.name = "Urlscan";
   }
 
-  public searchByIP(query) {
+  searchByIP(query) {
     const encoded = encodeURIComponent(query);
     return this.search(encoded);
   }
 
-  public searchByDomain(query) {
+  searchByDomain(query) {
     const encoded = encodeURIComponent(query);
     return this.search(encoded);
   }
 
-  public searchByURL(query) {
+  searchByURL(query) {
     const encoded = encodeURIComponent(`"${query}"`);
     return this.search(encoded);
   }
 
-  public search(query) {
+  search(query) {
     const url = `https://urlscan.io/search/`;
     return `${url}#${query}`;
   }

--- a/src/lib/searcher/viewdns.ts
+++ b/src/lib/searcher/viewdns.ts
@@ -2,24 +2,24 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class ViewDNS implements Searcher {
 
-  public endpoint: string;
-  public name;
-  public supportedTypes: SearchableType[] = ["ip", "domain", "email"];
+  endpoint: string;
+  name;
+  supportedTypes: SearchableType[] = ["ip", "domain", "email"];
 
   constructor() {
     this.endpoint = "https://viewdns.info";
     this.name = "ViewDNS";
   }
 
-  public searchByIP(query) {
+  searchByIP(query) {
     return `${this.endpoint}/reverseip/?t=1&host=${query}`;
   }
 
-  public searchByDomain(query) {
+  searchByDomain(query) {
     return `${this.endpoint}/iphistory/?domain=${query}`;
   }
 
-  public searchByEmail(query) {
+  searchByEmail(query) {
     return `${this.endpoint}/reversewhois/?q=${query}`;
   }
 }

--- a/src/lib/searcher/virustotal.ts
+++ b/src/lib/searcher/virustotal.ts
@@ -4,25 +4,25 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class VirusTotal implements Searcher {
 
-  public endpoint: string;
-  public name: string;
-  public supportedTypes: SearchableType[] = ["ip", "domain", "url", "hash"];
+  endpoint: string;
+  name: string;
+  supportedTypes: SearchableType[] = ["ip", "domain", "url", "hash"];
 
   constructor() {
     this.endpoint = "https://www.virustotal.com/#";
     this.name = "VirusTotal";
   }
 
-  public searchByIP(query) {
+  searchByIP(query) {
     return `${this.endpoint}/ip-address/${query}`;
   }
 
-  public searchByURL(q) {
+  searchByURL(q) {
     const hash = crypto.SHA256(this.normalizeURL(q));
     return `${this.endpoint}/url/${hash}`;
   }
 
-  public normalizeURL(q) {
+  normalizeURL(q) {
     const parsedUrl = url.parse(q);
     if (parsedUrl.pathname === "/" && q.slice(-1) !== "/") {
       return `${q}/`;
@@ -30,11 +30,11 @@ export class VirusTotal implements Searcher {
     return q;
   }
 
-  public searchByDomain(query) {
+  searchByDomain(query) {
     return `${this.endpoint}/domain/${query}`;
   }
 
-  public searchByHash(query) {
+  searchByHash(query) {
     return `${this.endpoint}/file/${query}`;
   }
 }

--- a/src/lib/searcher/vulmon.ts
+++ b/src/lib/searcher/vulmon.ts
@@ -2,16 +2,16 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class Vulmon implements Searcher {
 
-  public endpoint: string;
-  public name;
-  public supportedTypes: SearchableType[] = ["cve"];
+  endpoint: string;
+  name;
+  supportedTypes: SearchableType[] = ["cve"];
 
   constructor() {
     this.endpoint = "https://vulmon.com";
     this.name = "Vulmon";
   }
 
-  public searchByCVE(query) {
+  searchByCVE(query) {
     return `${this.endpoint}/vulnerabilitydetails?qid=${query}`;
   }
 }

--- a/src/lib/searcher/webanalyzer.ts
+++ b/src/lib/searcher/webanalyzer.ts
@@ -2,16 +2,16 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class WebAnalyzer implements Searcher {
 
-  public endpoint: string;
-  public name;
-  public supportedTypes: SearchableType[] = ["domain"];
+  endpoint: string;
+  name;
+  supportedTypes: SearchableType[] = ["domain"];
 
   constructor() {
     this.endpoint = "https://wa-com.com";
     this.name = "WebAnalyzer";
   }
 
-  public searchByDomain(query) {
+  searchByDomain(query) {
     return `${this.endpoint}/${query}`;
   }
 }

--- a/src/lib/searcher/xforce-exchange.ts
+++ b/src/lib/searcher/xforce-exchange.ts
@@ -2,24 +2,24 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class XForceExchange implements Searcher {
 
-  public endpoint: string;
-  public name: string;
-  public supportedTypes: SearchableType[] = ["ip", "domain", "hash"];
+  endpoint: string;
+  name: string;
+  supportedTypes: SearchableType[] = ["ip", "domain", "hash"];
 
   constructor() {
     this.endpoint = "https://exchange.xforce.ibmcloud.com";
     this.name = "X-Force-Exchange";
   }
 
-  public searchByIP(query) {
+  searchByIP(query) {
     return `${this.endpoint}/ip/${query}`;
   }
 
-  public searchByDomain(query) {
+  searchByDomain(query) {
     return `${this.endpoint}/url/${query}`;
   }
 
-  public searchByHash(query) {
+  searchByHash(query) {
     return `${this.endpoint}/malware/${query}`;
   }
 }

--- a/src/lib/searcher/zoomeye.ts
+++ b/src/lib/searcher/zoomeye.ts
@@ -2,16 +2,16 @@ import { SearchableType, Searcher } from "./searcher";
 
 export class ZoomEye implements Searcher {
 
-  public endpoint: string;
-  public name;
-  public supportedTypes: SearchableType[] = ["ip"];
+  endpoint: string;
+  name;
+  supportedTypes: SearchableType[] = ["ip"];
 
   constructor() {
     this.endpoint = "https://www.zoomeye.org";
     this.name = "ZoomEye";
   }
 
-  public searchByIP(query) {
+  searchByIP(query) {
     const encoded = encodeURIComponent(`ip:"${query}"`);
     return `${this.endpoint}/searchResult?q=${encoded}&t=host`;
   }

--- a/src/lib/selector.ts
+++ b/src/lib/selector.ts
@@ -20,27 +20,27 @@ export class Selector {
     this.ioc = getIOC(input);
   }
 
-  public getIP(): string | null {
+  getIP(): string | null {
     return this.getFirstValueFromArray(this.ioc.networks.ipv4s);
   }
 
-  public getDomain(): string | null {
+  getDomain(): string | null {
     return this.getFirstValueFromArray(this.ioc.networks.domains);
   }
 
-  public getURL(): string | null {
+  getURL(): string | null {
     return this.getFirstValueFromArray(this.ioc.networks.urls);
   }
 
-  public getEmail(): string | null {
+  getEmail(): string | null {
     return this.getFirstValueFromArray(this.ioc.networks.emails);
   }
 
-  public getASN(): string | null {
+  getASN(): string | null {
     return this.getFirstValueFromArray(this.ioc.networks.asns);
   }
 
-  public getHash(): string | null {
+  getHash(): string | null {
     let hashes: string[] = [];
     hashes = this.concat(hashes, this.ioc.hashes.sha256s);
     hashes = this.concat(hashes, this.ioc.hashes.sha1s);
@@ -51,35 +51,35 @@ export class Selector {
     return hashes[0];
   }
 
-  public getCVE(): string | null {
+  getCVE(): string | null {
     return this.getFirstValueFromArray(this.ioc.utilities.cves);
   }
 
-  public getBTC(): string | null {
+  getBTC(): string | null {
     return this.getFirstValueFromArray(this.ioc.cryptocurrencies.btcs);
   }
 
-  public getXMR(): string | null {
+  getXMR(): string | null {
     return this.getFirstValueFromArray(this.ioc.cryptocurrencies.xmrs);
   }
 
-  public getGATrackID(): string | null {
+  getGATrackID(): string | null {
     return this.getFirstValueFromArray(this.ioc.trackers.gaTrackIDs);
   }
 
-  public getGAPubID(): string | null {
+  getGAPubID(): string | null {
     return this.getFirstValueFromArray(this.ioc.trackers.gaPubIDs);
   }
 
-  public getSearchersByType(type: SearchableType) {
+  getSearchersByType(type: SearchableType) {
     return this.searchers.filter((searcher: Searcher) => searcher.supportedTypes.indexOf(type) !== -1);
   }
 
-  public getScannersByType(type: ScannableType) {
+  getScannersByType(type: ScannableType) {
     return this.scanners.filter((scanner: Scanner) => scanner.supportedTypes.indexOf(type) !== -1);
   }
 
-  public getSearcherEntries(): AnalyzerEntry[] {
+  getSearcherEntries(): AnalyzerEntry[] {
     let entries: AnalyzerEntry[] = [];
     entries = this.concat(entries, this.makeAnalyzerEntries(this.getSearchersByType("text"), "text", this.input));
 
@@ -130,7 +130,7 @@ export class Selector {
     return entries;
   }
 
-  public getScannerEntries(): AnalyzerEntry[] {
+  getScannerEntries(): AnalyzerEntry[] {
     const analyzerEntries: AnalyzerEntry[] = [];
 
     const url = this.getURL();


### PR DESCRIPTION
All members within class are public by default (and always public in runtime, TS private/protected will "hide" particular class properties/methods only during compile time).

Ref, https://medium.com/@martin_hotell/10-typescript-pro-tips-patterns-with-or-without-react-5799488d6680