### PR TITLE
refactor: revamp DomainWatch plugin

### DIFF
--- a/src/lib/searcher/domainwatch.ts
+++ b/src/lib/searcher/domainwatch.ts
@@ -12,7 +12,7 @@ export class DomainWatch implements Searcher {
   }
 
   public searchByDomain(query: string): string {
-    return buildURL(this.baseURL, `/whois/${query}`);
+    return buildURL(this.baseURL, `/site/${query}`);
   }
 
   public searchByEmail(query: string): string {

--- a/test/searcher/domainwatch.spec.ts
+++ b/test/searcher/domainwatch.spec.ts
@@ -12,7 +12,7 @@ describe("DomainWatch", function() {
   describe("#searchByDomain", function() {
     it("should return URL", function() {
       expect(subject.searchByDomain("github.com")).to.equal(
-        "https://domainwat.ch/whois/github.com"
+        "https://domainwat.ch/site/github.com"
       );
     });
   });


### PR DESCRIPTION
Prefer `site` lookup rather than `whois` lookup