### PR TITLE
Renew searchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ Mitaka is a browser extension that makes your OSINT (Open Source Intelligence) s
 | Hashdd               | https://hashdd.com                     | Hash                                                                 |
 | Hurricane Electric   | https://bgp.he.net/                    | IP, domain, ASN                                                      |
 | HybridAnalysis       | https://www.hybrid-analysis.com        | IP, domain, hash                                                     |
-| Intelligence X       | https://intelx.io                      | IP, domain, URL, email, BTC                                          |
 | Intezer              | https://analyze.intezer.com            | Hash                                                                 |
 | IPinfo               | https://ipinfo.io                      | IP, ASN                                                              |
 | IPIP                 | https://en.ipip.net                    | IP, ASN                                                              |

--- a/src/searcher/censys.ts
+++ b/src/searcher/censys.ts
@@ -24,14 +24,16 @@ export class Censys implements Searcher {
   }
 
   public searchByDomain(query: string): string {
-    return buildURL(this.baseURL, "/certificates", {
+    return buildURL(this.baseURL, "/search", {
       q: `parsed.names:${query}`,
+      resource: "certificates",
     });
   }
 
   public searchByEmail(query: string): string {
-    return buildURL(this.baseURL, "/certificates", {
+    return buildURL(this.baseURL, "/search", {
       q: `parsed.subject.email_address:${query}`,
+      resource: "certificates",
     });
   }
 }

--- a/src/searcher/index.ts
+++ b/src/searcher/index.ts
@@ -1,6 +1,5 @@
 import type { Searcher } from "~/types";
 
-import { Coalition } from "./coalition";
 import {
   AbuseIPDB,
   AnyRun,
@@ -17,6 +16,7 @@ import {
   Censys,
   CheckPhish,
   Crtsh,
+  Coalition,
   DNSlytics,
   DomainTools,
   EmailRep,
@@ -29,7 +29,6 @@ import {
   HurricaneElectric,
   HybridAnalysis,
   InQuest,
-  IntelligenceX,
   Intezer,
   IPinfo,
   IPIP,
@@ -174,7 +173,6 @@ export const Searchers: Searcher[] = [
   new HurricaneElectric(),
   new HybridAnalysis(),
   new InQuest(),
-  new IntelligenceX(),
   new Intezer(),
   new IPinfo(),
   new IPIP(),

--- a/tests/searcher/censys.spec.ts
+++ b/tests/searcher/censys.spec.ts
@@ -29,7 +29,7 @@ describe("Censys", function () {
     const domain = "github.com";
     it("should return a URL", function () {
       expect(subject.searchByDomain(domain)).toBe(
-        "https://search.censys.io/certificates?q=parsed.names%3Agithub.com",
+        "https://search.censys.io/search?q=parsed.names%3Agithub.com&resource=certificates",
       );
     });
   });
@@ -38,7 +38,7 @@ describe("Censys", function () {
     const email = "test@test.com";
     it("should return a URL", function () {
       expect(subject.searchByEmail(email)).toBe(
-        "https://search.censys.io/certificates?q=parsed.subject.email_address%3Atest%40test.com",
+        "https://search.censys.io/search?q=parsed.subject.email_address%3Atest%40test.com&resource=certificates",
       );
     });
   });


### PR DESCRIPTION
- Update Censys's search queries
- Disable IntelligenceX (since now I don't see a point of this integration)