### PR TITLE
Fixed URL path for joesandbox.

### DIFF
--- a/src/searcher/joesandbox.ts
+++ b/src/searcher/joesandbox.ts
@@ -17,6 +17,6 @@ export class JoeSandbox extends Base {
   }
 
   public searchByHash(query: string) {
-    return ok(buildURL(this.baseURL, `/search`, { q: query }));
+    return ok(buildURL(this.baseURL, `/analysis/search`, { q: query }));
   }
 }

--- a/tests/searcher/joesandbox.spec.ts
+++ b/tests/searcher/joesandbox.spec.ts
@@ -11,7 +11,7 @@ describe("JoeSandbox", function () {
     const hash = "44d88612fea8a8f36de82e1278abb02f";
     it("should return a URL", function () {
       expect(subject.searchByHash(hash)._unsafeUnwrap()).toBe(
-        `https://www.joesandbox.com/search?q=${hash}`,
+        `https://www.joesandbox.com/analysis/search?q=${hash}`,
       );
     });
   });


### PR DESCRIPTION
The path in the JoeSandbox URL was wrong and I fixed it.

Example of correct URL: https://www.joesandbox.com/analysis/search?q=44d88612fea8a8f36de82e1278abb02f