### PR TITLE
Enhance ONYPHE search

### DIFF
--- a/src/command/runner.ts
+++ b/src/command/runner.ts
@@ -23,6 +23,11 @@ export class CommandRunner {
 
   private searcherMap: SearcherMap = {
     ip: (searcher: Searcher, query: string): Result<string, string> => {
+      // Only pass the second argument if the searcher is ONYPHE and onypheType is present
+      if (searcher.name === "ONYPHE" && this.command.onypheType) {
+        // Pass the type string directly for ONYPHE
+        return searcher.searchByIP(query, this.command.onypheType);
+      }
       return searcher.searchByIP(query);
     },
     domain: (searcher: Searcher, query: string): Result<string, string> => {

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -29,11 +29,38 @@ export function createContextMenus(text: string, options: OptionsType): void {
       }
       return "scan";
     })();
+    // Special handling for Onyphe IP search: add both datascan and ctiscan
+    if (name === "ONYPHE" && slot.type === "ip") {
+      ([
+        { type: "datascan" as const, label: "datascan" },
+        { type: "ctiscan" as const, label: "ctiscan" },
+      ]).forEach(({ type, label }) => {
+        const command: CommandType = {
+          action,
+          name,
+          query: slot.query,
+          type: slot.type,
+          onypheType: type,
+        };
+        const id = commandToID(command);
+        // Simpler title: Search <ip> as IP on ONYPHE (datascan/ctiscan)
+        const title = `Search ${slot.query} as IP on ONYPHE (${label})`;
+        chrome.contextMenus.create({ contexts, id, title }, () => {
+          if (options.debug) {
+            // eslint-disable-next-line no-console
+            console.debug(`Mitaka: context menu:${id} created`);
+          }
+        });
+      });
+      continue;
+    }
+    // Default: normal menu item
     const command: CommandType = {
       action,
       name,
       query: slot.query,
       type: slot.type,
+      onypheType: undefined, // Explicitly set to satisfy the type
     };
     // it tells action, query, type and target to the listener
     const id = commandToID(command);
@@ -62,7 +89,6 @@ export default defineBackground(() => {
     const id: string = info.menuItemId.toString();
     const command = v.parse(CommandSchema, JSON.parse(id));
     const options = await getOptions();
-
     const runner = new CommandRunner(command, options);
     switch (runner.command.action) {
       case "search":

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -65,6 +65,10 @@ export const CommandSchema = v.object({
   query: v.string(),
   type: Searchable,
   name: v.string(),
+  // Optional property for Onyphe search type
+  onypheType: v.optional(v.union([v.literal("datascan"), v.literal("ctiscan")]), undefined),
 });
 
-export type CommandType = v.InferOutput<typeof CommandSchema>;
+export type CommandType = v.InferOutput<typeof CommandSchema> & {
+  onypheType?: "datascan" | "ctiscan";
+};

--- a/src/searcher/onyphe.ts
+++ b/src/searcher/onyphe.ts
@@ -12,11 +12,25 @@ export class ONYPHE extends Base {
 
   public constructor() {
     super();
-    this.baseURL = "https://www.onyphe.io";
+    this.baseURL = "https://search.onyphe.io";
     this.name = "ONYPHE";
   }
 
-  public searchByIP(query: string) {
-    return ok(buildURL(this.baseURL, `/summary/ip/${query}`));
+  /**
+   * Search Onyphe by IP with selectable category.
+   * @param query IP address
+   * @param type "datascan" | "ctiscan" (default: datascan)
+   */
+  public searchByIP(query: string, type: "datascan" | "ctiscan" = "datascan") {
+    if (type === "ctiscan") {
+      // ctiscan uses ip.dest, not ip
+      return ok(
+        buildURL(this.baseURL, "/search", { q: `category:ctiscan ip.dest:${query}` })
+      );
+    }
+    // default: datascan
+    return ok(
+      buildURL(this.baseURL, "/search", { q: `category:datascan ip:${query}` })
+    );
   }
 }

--- a/src/searcher/zoomeye.ts
+++ b/src/searcher/zoomeye.ts
@@ -1,5 +1,5 @@
-import { ok } from "neverthrow";
 import { Base64 } from "js-base64";
+import { ok } from "neverthrow";
 
 import type { SearchableType } from "~/schemas";
 import { buildURL } from "~/utils";

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,7 @@ export interface Searcher {
   searchByGAPubID(quqery: string): Result<string, string>;
   searchByGATrackID(query: string): Result<string, string>;
   searchByHash(query: string): Result<string, string>;
-  searchByIP(query: string): Result<string, string>;
+  searchByIP(query: string, type?: string): Result<string, string>;
   searchByURL(query: string): Result<string, string>;
   searchByXMR(query: string): Result<string, string>;
 }

--- a/tests/searcher/onyphe.spec.ts
+++ b/tests/searcher/onyphe.spec.ts
@@ -9,9 +9,14 @@ describe("ONYPHE", function () {
 
   describe("#searchByIP", function () {
     const ip = "1.1.1.1";
-    it("should return a URL", function () {
+    it("should return datascan URL by default", function () {
       expect(subject.searchByIP(ip)._unsafeUnwrap()).toBe(
-        `https://www.onyphe.io/summary/ip/${ip}`,
+        "https://search.onyphe.io/search?q=category%3Adatascan+ip%3A1.1.1.1"
+      );
+    });
+    it("should return ctiscan URL when type is ctiscan", function () {
+      expect(subject.searchByIP(ip, "ctiscan")._unsafeUnwrap()).toBe(
+        "https://search.onyphe.io/search?q=category%3Actiscan+ip.dest%3A1.1.1.1"
       );
     });
   });


### PR DESCRIPTION
Introduce type handling for IP queries in ONYPHE searches, allowing users to specify `datascan` or `ctiscan` categories.