### PR TITLE
Add Sherlockeye search engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Mitaka is a browser extension that makes your OSINT (Open Source Intelligence) s
 - Key features:
   - Auto IoC (indicators of compromise) selection with refanging.
     - E.g. `example[.]com` to `example.com`, `test[at]example.com` to `test@example.com`, `hxxp://example.com` to `http://example.com`, etc.
-  - Supports 65+ services.
+  - Supports 66+ services.
 
 ## Install
 
@@ -81,6 +81,7 @@ Mitaka is a browser extension that makes your OSINT (Open Source Intelligence) s
 | Robtex               | <https://www.robtex.com>                 | IP, domain                     |
 | Scumware             | <https://www.scumware.org>               | IP, domain, hash (MD5)         |
 | SecurityTrails       | <https://securitytrails.com>             | IP, domain                     |
+| Sherlockeye          | <https://app.sherlockeye.io>             | IP, domain, email              |
 | Shodan               | <https://www.shodan.io>                  | IP, domain, ASN                |
 | Sploitus             | <https://sploitus.com>                   | CVE                            |
 | SpyOnWeb             | <https://spyonweb.net>                   | IP, domain, gaPubID, gaTrackID |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Mitaka is a browser extension that makes your OSINT (Open Source Intelligence) s
 - Key features:
   - Auto IoC (indicators of compromise) selection with refanging.
     - E.g. `example[.]com` to `example.com`, `test[at]example.com` to `test@example.com`, `hxxp://example.com` to `http://example.com`, etc.
-  - Supports 66+ services.
+  - Supports 65+ services.
 
 ## Install
 

--- a/src/searcher/index.ts
+++ b/src/searcher/index.ts
@@ -40,6 +40,7 @@ import {
   Robtex,
   Scumware,
   SecurityTrails,
+  Sherlockeye,
   Shodan,
   Sploitus,
   SpyOnWeb,
@@ -101,6 +102,7 @@ export { Radar } from './radar'
 export { Robtex } from './robtex'
 export { Scumware } from './scumware'
 export { SecurityTrails } from './securitytrails'
+export { Sherlockeye } from './sherlockeye'
 export { Shodan } from './shodan'
 export { Sploitus } from './sploitus'
 export { SpyOnWeb } from './spyonweb'
@@ -161,6 +163,7 @@ export const Searchers: Searcher[] = [
   new Robtex(),
   new Scumware(),
   new SecurityTrails(),
+  new Sherlockeye(),
   new Shodan(),
   new Sploitus(),
   new SpyOnWeb(),

--- a/src/searcher/sherlockeye.ts
+++ b/src/searcher/sherlockeye.ts
@@ -1,0 +1,34 @@
+import { ok } from 'neverthrow'
+
+import type { SearchableType } from '~/schemas'
+import { buildURL } from '~/utils'
+
+import { Base } from './base'
+
+export class Sherlockeye extends Base {
+  public baseURL: string
+  public name: string
+  public supportedTypes: SearchableType[] = ['ip', 'domain', 'email']
+
+  public constructor() {
+    super()
+    this.baseURL = 'https://app.sherlockeye.io'
+    this.name = 'Sherlockeye'
+  }
+
+  public searchByIP(query: string) {
+    return this.search(query)
+  }
+
+  public searchByDomain(query: string) {
+    return this.search(query)
+  }
+
+  public searchByEmail(query: string) {
+    return this.search(query)
+  }
+
+  private search(query: string) {
+    return ok(buildURL(this.baseURL, '/', { q: query }))
+  }
+}

--- a/tests/searcher/sherlockeye.spec.ts
+++ b/tests/searcher/sherlockeye.spec.ts
@@ -1,0 +1,35 @@
+import { Sherlockeye } from '~/searcher'
+
+describe('Sherlockeye', function () {
+  const subject = new Sherlockeye()
+
+  it('should support ip, domain and email', function () {
+    expect(subject.supportedTypes).toEqual(['ip', 'domain', 'email'])
+  })
+
+  describe('#searchByIP', function () {
+    const ip = '1.1.1.1'
+    it('should return a URL', function () {
+      expect(subject.searchByIP(ip)._unsafeUnwrap()).toBe('https://app.sherlockeye.io/?q=1.1.1.1')
+    })
+  })
+
+  describe('#searchByDomain', function () {
+    const domain = 'github.com'
+    it('should return a URL', function () {
+      expect(subject.searchByDomain(domain)._unsafeUnwrap()).toBe(
+        'https://app.sherlockeye.io/?q=github.com',
+      )
+    })
+  })
+
+  describe('#searchByEmail', function () {
+    const email = 'test@test.com'
+    it('should return a URL', function () {
+      expect(subject.searchByEmail(email)._unsafeUnwrap()).toBe(
+        'https://app.sherlockeye.io/?q=test%40test.com',
+      )
+    })
+  })
+
+})


### PR DESCRIPTION
## Summary

Adds [Sherlockeye](https://app.sherlockeye.io) as a new search engine, following the existing searcher pattern.

- New `Sherlockeye` searcher opens `https://app.sherlockeye.io/?q=<ioc>` for supported IoCs
- Supported types: **IP**, **domain**, and **email** (aligned with what Sherlockeye accepts via `?q=`)
- Registered in `Searchers`, documented in README, covered by unit tests

## Test plan

- [ ] Select an IP (e.g. `8.8.8.8`) → context menu shows **Search | Sherlockeye** → opens `https://app.sherlockeye.io/?q=8.8.8.8`
- [ ] Select a domain (e.g. `github.com`) → opens `https://app.sherlockeye.io/?q=github.com`
- [ ] Select an email → opens with encoded `@` in the query string
- [ ] Select a full URL (e.g. `https://github.com`) → Sherlockeye does **not** appear in the menu
- [ ] Options page → Sherlockeye can be enabled/disabled like other searchers
- [ ] `npm test -- tests/searcher/sherlockeye.spec.ts`